### PR TITLE
32 htmlcancel taglib not working in case of multipartrequestwrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.5.0-RC3 / YYYY-MM-DD
 
+* Add Method `RequestUtils.isRequestCancelled`
 * Fix for `#32 - html:cancel taglib not working in case of MultipartRequestWrapper` thanks to nrmnrm
 * Tiles: Correct `I18nFactorySet.initFactory` under windows
 * Set Version to 1.5.0-SNAPSHOT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.5.0-RC3 / YYYY-MM-DD
 
+* Second attempt to fix for `#32 - html:cancel taglib not working in case of MultipartRequestWrapper`
 * Add Method `RequestUtils.isRequestCancelled`
 * Fix for `#32 - html:cancel taglib not working in case of MultipartRequestWrapper` thanks to nrmnrm
 * Tiles: Correct `I18nFactorySet.initFactory` under windows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changes
 
-## 1.5.0 / YYYY-MM-DD
+## 1.5.0-RC3 / YYYY-MM-DD
 
+* Fix for `#32 - html:cancel taglib not working in case of MultipartRequestWrapper` thanks to nrmnrm
 * Tiles: Correct `I18nFactorySet.initFactory` under windows
 * Set Version to 1.5.0-SNAPSHOT
 * Update documentation to version 1.5.0

--- a/apps/examples/src/main/java/org/apache/struts/webapp/upload/UploadAction.java
+++ b/apps/examples/src/main/java/org/apache/struts/webapp/upload/UploadAction.java
@@ -28,14 +28,14 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-
 import org.apache.struts.action.Action;
 import org.apache.struts.action.ActionForm;
 import org.apache.struts.action.ActionForward;
 import org.apache.struts.action.ActionMapping;
 import org.apache.struts.upload.FormFile;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 
 
@@ -59,8 +59,12 @@ public class UploadAction extends Action
                                  HttpServletResponse response)
         throws Exception {
 
-        if (form instanceof UploadForm) {
+        // Was this transaction cancelled?
+        if (isCancelled(request)) {
+            return mapping.findForward("home");
+        }
 
+        if (form instanceof UploadForm) {
             //this line is here for when the input page is upload-utf8.jsp,
             //it sets the correct character encoding for the response
             String encoding = request.getCharacterEncoding();
@@ -150,8 +154,8 @@ public class UploadAction extends Action
             request.setAttribute("size", size);
             request.setAttribute("data", data);
 
-            //destroy the temporary file created
-            file.destroy();
+            //destroy temporary files
+            form.getMultipartRequestHandler().finish();
 
             //return a forward to display.jsp
             return mapping.findForward("display");

--- a/apps/examples/src/main/webapp/WEB-INF/upload/struts-config.xml
+++ b/apps/examples/src/main/webapp/WEB-INF/upload/struts-config.xml
@@ -23,8 +23,12 @@
         <form-bean name="uploadForm"
                    type="org.apache.struts.webapp.upload.UploadForm"/>
     </form-beans>
-    <action-mappings>
 
+    <global-forwards>
+        <forward name="home" path="/welcome.do" module=""/>
+    </global-forwards>
+
+    <action-mappings>
         <action path="/upload" forward="/upload.jsp"/>
 
         <!-- Upload Action -->
@@ -33,6 +37,7 @@
                 name="uploadForm"
                 scope="request"
                 validate="true"
+                cancellable="true"
                 input="input">
             <forward name="input" path="/upload.jsp"/>
             <forward name="display" path="/display.jsp"/>
@@ -47,6 +52,7 @@
                 name="uploadForm"
                 scope="request"
                 validate="true"
+                cancellable="true"
                 input="input">
             <forward name="input" path="/upload2.jsp"/>
             <forward name="display" path="/display.jsp"/>
@@ -61,6 +67,7 @@
                 name="uploadForm"
                 scope="request"
                 validate="true"
+                cancellable="true"
                 input="input">
             <forward name="input" path="/upload-multi.jsp"/>
             <forward name="display" path="/display.jsp"/>

--- a/apps/examples/src/main/webapp/upload/upload-multi.jsp
+++ b/apps/examples/src/main/webapp/upload/upload-multi.jsp
@@ -45,7 +45,7 @@
     <p>If you checked the box to write to a file, please specify the file path here: <br />
     <html:text property="filePath"  errorStyle="background-color: yellow"/></p>
     <p>
-    <html:submit />
+    <html:submit />&nbsp;<html:cancel />
     </p>
     </html:form>
 

--- a/apps/examples/src/main/webapp/upload/upload-utf8.jsp
+++ b/apps/examples/src/main/webapp/upload/upload-utf8.jsp
@@ -41,6 +41,7 @@
     <html:text property="filePath" />
     <br />
     <br />
-    <html:submit /></html:form>
+    <html:submit />&nbsp;<html:cancel />
+    </html:form>
   </body>
 </html>

--- a/apps/examples/src/main/webapp/upload/upload.jsp
+++ b/apps/examples/src/main/webapp/upload/upload.jsp
@@ -45,7 +45,7 @@
     <p>If you checked the box to write to a file, please specify the file path here: <br />
     <html:text property="filePath"  errorStyle="background-color: yellow"/></p>
     <p>
-    <html:submit />
+    <html:submit />&nbsp;<html:cancel />
     </p>
     </html:form>
 

--- a/apps/examples/src/main/webapp/upload/upload2.jsp
+++ b/apps/examples/src/main/webapp/upload/upload2.jsp
@@ -46,7 +46,7 @@
     <p>If you checked the box to write to a file, please specify the file path here: <br />
     <html:text property="filePath"  errorStyle="background-color: yellow"/></p>
     <p>
-    <html:submit />
+    <html:submit />&nbsp;<html:cancel />
     </p>
     </html:form>
 

--- a/core/src/main/java/org/apache/struts/action/Action.java
+++ b/core/src/main/java/org/apache/struts/action/Action.java
@@ -23,19 +23,19 @@ package org.apache.struts.action;
 import java.io.Serializable;
 import java.util.Locale;
 
-import jakarta.servlet.ServletContext;
-import jakarta.servlet.ServletRequest;
-import jakarta.servlet.ServletResponse;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import jakarta.servlet.http.HttpSession;
-
 import org.apache.struts.Globals;
 import org.apache.struts.config.ModuleConfig;
 import org.apache.struts.util.MessageResources;
 import org.apache.struts.util.ModuleUtils;
 import org.apache.struts.util.RequestUtils;
 import org.apache.struts.util.TokenProcessor;
+
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 
 /**
  * <p>An <strong>Action</strong> is an adapter between the contents of an
@@ -403,7 +403,7 @@ public class Action implements Serializable {
      *         <code>false</code> otherwise.
      */
     protected boolean isCancelled(HttpServletRequest request) {
-        return (request.getAttribute(Globals.CANCEL_KEY) != null);
+        return RequestUtils.isRequestCancelled(request);
     }
 
     /**

--- a/core/src/main/java/org/apache/struts/action/RequestProcessor.java
+++ b/core/src/main/java/org/apache/struts/action/RequestProcessor.java
@@ -25,13 +25,6 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Locale;
 
-import jakarta.servlet.RequestDispatcher;
-import jakarta.servlet.ServletContext;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import jakarta.servlet.http.HttpSession;
-
 import org.apache.struts.Globals;
 import org.apache.struts.config.ActionConfig;
 import org.apache.struts.config.ExceptionConfig;
@@ -42,6 +35,13 @@ import org.apache.struts.util.MessageResources;
 import org.apache.struts.util.RequestUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 
 /**
  * <p><strong>RequestProcessor</strong> contains the processing logic that the
@@ -805,7 +805,7 @@ public class RequestProcessor implements Serializable {
         }
 
         RequestUtils.populate(form, mapping.getPrefix(), mapping.getSuffix(),
-            request);
+            request, RequestUtils.populateMultipartPost(request));
 
         // Set the cancellation request attribute if appropriate
         if ((request.getParameter(Globals.CANCEL_PROPERTY) != null)

--- a/core/src/main/java/org/apache/struts/chain/commands/AbstractPopulateActionForm.java
+++ b/core/src/main/java/org/apache/struts/chain/commands/AbstractPopulateActionForm.java
@@ -59,9 +59,6 @@ public abstract class AbstractPopulateActionForm extends ActionCommandBase {
         ActionConfig actionConfig = actionCtx.getActionConfig();
         ActionForm actionForm = actionCtx.getActionForm();
 
-        // First determine if the request was cancelled
-        handleCancel(actionCtx, actionConfig, actionForm);
-
         // Is there a form bean for this request?
         if (actionForm == null) {
             return (false);
@@ -78,6 +75,9 @@ public abstract class AbstractPopulateActionForm extends ActionCommandBase {
             log.debug("Populating form bean '{}'", actionConfig.getName());
             populate(actionCtx, actionConfig, actionForm);
         }
+
+        // Always handle cancel last, as it needs populate first
+        handleCancel(actionCtx, actionConfig, actionForm);
 
         return CONTINUE_PROCESSING;
     }

--- a/core/src/main/java/org/apache/struts/chain/commands/servlet/PopulateActionForm.java
+++ b/core/src/main/java/org/apache/struts/chain/commands/servlet/PopulateActionForm.java
@@ -20,7 +20,6 @@
  */
 package org.apache.struts.chain.commands.servlet;
 
-import org.apache.struts.Globals;
 import org.apache.struts.action.ActionForm;
 import org.apache.struts.action.ActionMapping;
 import org.apache.struts.chain.commands.AbstractPopulateActionForm;
@@ -28,6 +27,7 @@ import org.apache.struts.chain.contexts.ActionContext;
 import org.apache.struts.chain.contexts.ServletActionContext;
 import org.apache.struts.config.ActionConfig;
 import org.apache.struts.config.PopulateEvent;
+import org.apache.struts.upload.MultipartRequestHandler;
 import org.apache.struts.util.RequestUtils;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -44,30 +44,21 @@ public class PopulateActionForm extends AbstractPopulateActionForm {
     // ------------------------------------------------------- Protected Methods
 
     protected void populate(ActionContext context, ActionConfig actionConfig,
-        ActionForm actionForm)
+        ActionForm actionForm, MultipartRequestHandler multipartHandler)
         throws Exception {
         ServletActionContext saContext = (ServletActionContext) context;
         HttpServletRequest request = saContext.getRequest();
 
         RequestUtils.populate(actionForm, actionConfig.getPrefix(),
-            actionConfig.getSuffix(), request);
+            actionConfig.getSuffix(), request, multipartHandler);
     }
 
     protected void reset(ActionContext context, ActionConfig actionConfig,
         ActionForm actionForm) {
-
         ServletActionContext saContext = (ServletActionContext) context;
         HttpServletRequest request = saContext.getRequest();
 
-        if (actionForm != null) {
-            actionForm.reset((ActionMapping) actionConfig, request);
-        }
-
-        // Set the multipart class
-        if (actionConfig.getMultipartClass() != null) {
-            saContext.getRequestScope().put(Globals.MULTIPART_KEY,
-                actionConfig.getMultipartClass());
-        }
+        actionForm.reset((ActionMapping) actionConfig, request);
     }
 
     // ---------------------------------------------------------- Helper Methods
@@ -146,6 +137,10 @@ public class PopulateActionForm extends AbstractPopulateActionForm {
                 }
             } else if (attribute.equals(PopulateEvent.CHAIN)) {
                 if (RequestUtils.isRequestChained(request)) {
+                    return true;
+                }
+            } else if (attribute.equals(PopulateEvent.CANCEL)) {
+                if (RequestUtils.isRequestCancelled(request)) {
                     return true;
                 }
             } else if (attribute.equals(PopulateEvent.REQUEST)) {

--- a/core/src/main/java/org/apache/struts/chain/commands/servlet/PopulateActionForm.java
+++ b/core/src/main/java/org/apache/struts/chain/commands/servlet/PopulateActionForm.java
@@ -55,10 +55,13 @@ public class PopulateActionForm extends AbstractPopulateActionForm {
 
     protected void reset(ActionContext context, ActionConfig actionConfig,
         ActionForm actionForm) {
+
         ServletActionContext saContext = (ServletActionContext) context;
         HttpServletRequest request = saContext.getRequest();
 
-        actionForm.reset((ActionMapping) actionConfig, request);
+        if (actionForm != null) {
+            actionForm.reset((ActionMapping) actionConfig, request);
+        }
 
         // Set the multipart class
         if (actionConfig.getMultipartClass() != null) {

--- a/core/src/main/java/org/apache/struts/util/RequestUtils.java
+++ b/core/src/main/java/org/apache/struts/util/RequestUtils.java
@@ -1212,6 +1212,22 @@ public class RequestUtils {
     }
 
     /**
+     * Verifies whether current request is cancelled or not.
+     *
+     * @param request current HTTP request
+     * @return {@code true} if the request is cancelled; otherwise {@code false}
+     * @since Struts 1.5
+     */
+    public static boolean isRequestCancelled(HttpServletRequest request) {
+        final Object value = request.getAttribute(Globals.CANCEL_KEY);
+        if (value instanceof Boolean) {
+            return ((Boolean) value).booleanValue();
+        } else {
+            return false;
+        }
+    }
+
+    /**
      * Verifies whether the current request is a multipart-post-request.
      *
      * @param request current HTTP request

--- a/extras/src/main/java/org/apache/struts/extras/actions/ActionDispatcher.java
+++ b/extras/src/main/java/org/apache/struts/extras/actions/ActionDispatcher.java
@@ -24,11 +24,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.HashMap;
 
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-
-import org.apache.struts.Globals;
 import org.apache.struts.action.Action;
 import org.apache.struts.action.ActionForm;
 import org.apache.struts.action.ActionForward;
@@ -37,8 +32,13 @@ import org.apache.struts.chain.contexts.ActionContext;
 import org.apache.struts.chain.contexts.ServletActionContext;
 import org.apache.struts.dispatcher.Dispatcher;
 import org.apache.struts.util.MessageResources;
+import org.apache.struts.util.RequestUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * <p>Action <i>helper</i> class that dispatches to a public method in an
@@ -496,7 +496,7 @@ public class ActionDispatcher implements Dispatcher {
      * @see org.apache.struts.taglib.html.CancelTag
      */
     protected boolean isCancelled(HttpServletRequest request) {
-        return (request.getAttribute(Globals.CANCEL_KEY) != null);
+        return RequestUtils.isRequestCancelled(request);
     }
 
     /**

--- a/src/site/xdoc/userGuide/release-notes.xml
+++ b/src/site/xdoc/userGuide/release-notes.xml
@@ -97,6 +97,7 @@
             <subsection name="Issue Tracking" id="Highlight">
 <h4>Bug</h4>
 <ul>
+<li>Second attempt to fix for &quot;#32 - html:cancel taglib not working in case of MultipartRequestWrapper&quot;</li>
 <li>Fix for &quot;#32 - html:cancel taglib not working in case of MultipartRequestWrapper&quot; thanks to nrmnrm</li>
 <li>Tiles: Correct &quot;I18nFactorySet.initFactory&quot; under windows</li>
 <li>With <strong>Release Candidate 1 &amp; 2</strong>:

--- a/src/site/xdoc/userGuide/release-notes.xml
+++ b/src/site/xdoc/userGuide/release-notes.xml
@@ -118,6 +118,7 @@
 
 <h4>Improvement</h4>
 <ul>
+<li>Add Method &quot;RequestUtils.isRequestCancelled&quot;</li>
 <li>With <strong>Release Candidate 1 &amp; 2</strong>:
     <ul>
         <li>Replace &quot;maven-bundle-plugin&quot; 5.1.9 with &quot;bnd-maven-plugin&quot; 7.0.0</li>

--- a/src/site/xdoc/userGuide/release-notes.xml
+++ b/src/site/xdoc/userGuide/release-notes.xml
@@ -97,6 +97,7 @@
             <subsection name="Issue Tracking" id="Highlight">
 <h4>Bug</h4>
 <ul>
+<li>Fix for &quot;#32 - html:cancel taglib not working in case of MultipartRequestWrapper&quot; thanks to nrmnrm</li>
 <li>Tiles: Correct &quot;I18nFactorySet.initFactory&quot; under windows</li>
 <li>With <strong>Release Candidate 1 &amp; 2</strong>:
     <ul>


### PR DESCRIPTION
Hi @nrmnrm,

sorry for the delay (vacation).
Thank you for your work! I think the change is from https://github.com/apache/struts1/commit/e2602abef14a7171020e81c64bcbdc54d920f4b4 / [STR-1674 - Cancellation does not work as intended without form](https://issues.apache.org/jira/browse/STR-1674).

As I saw in the Issue, the goal was that no population would be performed on a cancellation. What do you think of my suggestion?

Please take a look at it.

Greetings
Stefan