### PR TITLE
update commons-fileupload2-2.0.0-M1 to commons-fileupload2-servlet5-2…

### DIFF
--- a/apps/examples/pom.xml
+++ b/apps/examples/pom.xml
@@ -49,7 +49,7 @@
       </dependency>
       <dependency>
          <groupId>org.apache.commons</groupId>
-         <artifactId>commons-fileupload2-jakarta</artifactId>
+         <artifactId>commons-fileupload2-jakarta-servlet5</artifactId>
       </dependency>
       <dependency>
          <groupId>commons-io</groupId>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -170,7 +170,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
-      <artifactId>commons-fileupload2-jakarta</artifactId>
+      <artifactId>commons-fileupload2-jakarta-servlet5</artifactId>
       <optional>false</optional>
     </dependency>
     <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -95,7 +95,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
-            <artifactId>commons-fileupload2-jakarta</artifactId>
+            <artifactId>commons-fileupload2-jakarta-servlet5</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-beanutils</groupId>

--- a/core/src/main/java/org/apache/struts/upload/CommonsMultipartRequestHandler.java
+++ b/core/src/main/java/org/apache/struts/upload/CommonsMultipartRequestHandler.java
@@ -41,7 +41,7 @@ import org.apache.commons.fileupload2.core.FileUploadByteCountLimitException;
 import org.apache.commons.fileupload2.core.FileUploadException;
 import org.apache.commons.fileupload2.core.FileUploadFileCountLimitException;
 import org.apache.commons.fileupload2.core.FileUploadSizeException;
-import org.apache.commons.fileupload2.jakarta.JakartaServletFileUpload;
+import org.apache.commons.fileupload2.jakarta.servlet5.JakartaServletFileUpload;
 import org.apache.struts.Globals;
 import org.apache.struts.action.ActionMapping;
 import org.apache.struts.action.ActionServlet;
@@ -578,8 +578,13 @@ public class CommonsMultipartRequestHandler implements MultipartRequestHandler {
             return item.getString(StandardCharsets.ISO_8859_1);
         } catch (IOException e) {
             log.info("FileItem-getString", e);
-            return item.getString();
+            try {
+                return item.getString();
+            } catch (IOException ex) {
+                log.info("FileItem-getString with default encoding", e);
+            }
         }
+        return null;
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -394,7 +394,7 @@
         <jsfImplVersion>3.0.5</jsfImplVersion>
         <jaxbVersion>2.3.9</jaxbVersion>
         <junitVersion>5.10.2</junitVersion>
-        <fileuploadVersion>2.0.0-M1</fileuploadVersion>
+        <fileuploadVersion>2.0.0-M4</fileuploadVersion>
         <commonsChainVersion>1.3.0</commonsChainVersion>
         <struts.osgi.symbolicName>org.apache.${project.artifactId}</struts.osgi.symbolicName>
         <struts.osgi.export>!**.doc-files,org.apache.struts.*;version=${project.version}</struts.osgi.export>
@@ -678,8 +678,8 @@
                             </dependencyLink>
                             <dependencyLink>
                                 <groupId>org.apache.commons</groupId>
-                                <artifactId>commons-fileupload2-jakarta</artifactId>
-                                <url>https://javadoc.io/doc/org.apache.commons/commons-fileupload2-jakarta/${fileuploadVersion}/</url>
+                                <artifactId>commons-fileupload2-jakarta-servlet5</artifactId>
+                                <url>https://javadoc.io/doc/org.apache.commons/commons-fileupload2-jakarta-servlet5/${fileuploadVersion}/</url>
                             </dependencyLink>
                         </dependencyLinks>
                         <links>
@@ -1061,14 +1061,14 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
-                <artifactId>commons-fileupload2-jakarta</artifactId>
+                <artifactId>commons-fileupload2-jakarta-servlet5</artifactId>
                 <version>${fileuploadVersion}</version>
                 <optional>true</optional>
             </dependency>
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.15.1</version>
+                <version>2.19.0</version>
                 <optional>true</optional>
             </dependency>
             <dependency>


### PR DESCRIPTION
fixes issue #51 
additionally fixes CVE-2025-48976
Update commons-fileupload2 v2.0.0-M1 to commons-fileupload2-jakarta-servlet5 v2.0.0-M4. Versions before M4 has CVE-2025-48976 vulnerability. 
I decided to upgrade commons-fileupload2 to commons-jakarta-servlet5 instead of jakarta-servlet6 because the readme states that Struts v1.5 only supports Servlet 5 specification. 
Additionally, I had to upgrade commons-io to version 2.19.